### PR TITLE
Ensure suffix always applied to source dist.

### DIFF
--- a/enscons/pytar.py
+++ b/enscons/pytar.py
@@ -76,6 +76,7 @@ TarBuilder = SCons.Builder.Builder(
     source_scanner=SCons.Defaults.DirScanner,
     suffix="$TARSUFFIX",
     multi=True,
+    ensure_suffix=True,
 )
 
 


### PR DESCRIPTION
This fixes the problem where the base name ends with something that already looks like a suffix.

In particular, the name `chiabip158-0.13.dev3` was not getting the `.tar.gz` suffix.