### PR TITLE
Add auto-build & upload.

### DIFF
--- a/.github/workflows/upload-pypi-source.yml
+++ b/.github/workflows/upload-pypi-source.yml
@@ -1,0 +1,48 @@
+name: Build
+
+on: [push, pull_request]
+
+jobs:
+  upload_source_dist:
+    name: Upload source distribution
+    runs-on: [macos-latest]
+
+    steps:
+    - uses: actions/checkout@v1
+      with:
+        fetch-depth: 0
+        # we need fetch-depth 0 so setuptools_scm can resolve tags
+    - uses: actions/setup-python@v1
+      name: Install Python
+      with:
+        python-version: '3.7'
+
+    - name: Build source distribution
+      run: |
+        pip install pep517
+        python -m pep517.build --source --out-dir dist .
+
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v1
+      with:
+        name: dist
+        path: ./dist
+
+    - name: Install twine
+      run: pip install twine
+
+    - name: Publish distribution to Test PyPI
+      env:
+        TWINE_REPOSITORY_URL: https://test.pypi.org/legacy/
+        TWINE_USERNAME: __token__
+        TWINE_NON_INTERACTIVE: 1
+        TWINE_PASSWORD: ${{ secrets.test_pypi_password }}
+      run: twine upload --non-interactive --skip-existing --verbose 'dist/*'
+
+    - name: Publish distribution to PyPI
+      if: startsWith(github.event.ref, 'refs/tags')
+      env:
+        TWINE_USERNAME: __token__
+        TWINE_NON_INTERACTIVE: 1
+        TWINE_PASSWORD: ${{ secrets.pypi_password }}
+      run: twine upload --non-interactive --skip-existing --verbose 'dist/*'


### PR DESCRIPTION
You may find this script useful. It builds the source distribution as a github action and drops it as a downloadable artifact.

If you put in a couple API keys from test.pypi.org and pypi.org, it will also automatically upload (always for test.pypi.org and for releases that are tagged for pypi.org). I can walk you through the process if you want.

I believe this to be secure, but I recommend you audit it yourself before adding pypi.org secrets to github.