### PR TITLE
Fix cp37m problem on win32. Start using `packaging`.

### DIFF
--- a/enscons/tags.py
+++ b/enscons/tags.py
@@ -35,6 +35,8 @@ import warnings
 
 import attr
 
+from packaging import tags
+
 
 INTERPRETER_SHORT_NAMES = {
     "python": "py",  # Generic.
@@ -80,6 +82,14 @@ def _cpython_interpreter(py_version):
     return "cp{major}{minor}".format(major=py_version[0], minor=py_version[1])
 
 
+def _use_malloc():
+    with_pymalloc = sysconfig.get_config_var("WITH_PYMALLOC")
+    if with_pymalloc is None:
+        impl = tags.interpreter_name()
+        return impl == 'cp'
+    return False
+
+
 # TODO: This code is simpler compared to pep425tags as CPython 2.7 didn't seem
 #       to need the fallbacks. Is that acceptable?
 def _cpython_abi(py_version):
@@ -90,7 +100,7 @@ def _cpython_abi(py_version):
         found_options = [str(py_version[0]), str(py_version[1])]
         if sysconfig.get_config_var("Py_DEBUG"):
             found_options.append("d")
-        if sysconfig.get_config_var("WITH_PYMALLOC"):
+        if _use_malloc():
             found_options.append("m")
         if sysconfig.get_config_var("Py_UNICODE_SIZE") == 4:
             found_options.append("u")

--- a/enscons/tags.py
+++ b/enscons/tags.py
@@ -86,7 +86,7 @@ def _use_malloc():
     with_pymalloc = sysconfig.get_config_var("WITH_PYMALLOC")
     if with_pymalloc is None:
         impl = tags.interpreter_name()
-        return impl == 'cp'
+        return impl == 'cp' and sys.version_info < (3, 8)
     return False
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "enscons.api"
 name="enscons"
 version="0.23.0"
 packages=["enscons"]
-install_requires=["scons>=3.0.5", "pytoml>=0.1", "setuptools", "wheel", "attrs"]
+install_requires=["scons>=3.0.5", "pytoml>=0.1", "setuptools", "wheel", "attrs", "packaging"]
 description="Tools for building Python packages with SCons"
 description_file="README.rst"
 license="MIT"


### PR DESCRIPTION
See https://github.com/pypa/wheel/blob/a51977075740fda01b2c0e983a79bfe753567219/src/wheel/bdist_wheel.py#L80 for how this differed from `wheel`.

It'd be nice to be able to use these functions from `wheel`. However, the relevant API is in a file named `bdist_wheel.py` which doesn't seem quite kosher. Maybe we can move it to somewhere reasonable, declare it public, then start using it in `enscons`.