### PR TITLE
Support PEP 621 metadata keys

### DIFF
--- a/enscons/__init__.py
+++ b/enscons/__init__.py
@@ -190,7 +190,7 @@ def _is_string(obj):
 
 
 def _read_file(filename, encoding="utf-8"):
-    with codecs.open(filename, mode="r", encoding="utf-8") as f:
+    with codecs.open(filename, mode="r", encoding=encoding) as f:
         return f.read()
 
 
@@ -264,7 +264,7 @@ def metadata_builder(target, source, env):
             if "author_email" in metadata:
                 _write_header(f, "Author-email", metadata["author_email"])
         if "maintainers" in metadata:
-            _write_contacts(f, "Maintainers", "Maintainer-email", metadata["maintainers"])
+            _write_contacts(f, "Maintainer", "Maintainer-email", metadata["maintainers"])
         if "keywords" in metadata:
             _write_header(f, "Keywords",
                 metadata["keywords"] if _is_string(metadata["keywords"]) else \


### PR DESCRIPTION
By default PyPI expects the package descriptions to come in the RST format; if one wants to use e.g. Markdown, this can be done by adding the `Description-Content-Type` field to the METADATA file (i.e. PEP 566). This commit adds the ability to (optionally) set this field via the `description_content_type` key in the metadata. `Metadata-Version` is also bumped to 2.1 (as in PEP 566) because PyPI does not accept `Description-Content-Type` without this.